### PR TITLE
Add PyDataFrame.explain

### DIFF
--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -186,10 +186,4 @@ def test_explain(df):
         column("a") + column("b"),
         column("a") - column("b"),
     )
-
-    df = df.explain(False, False)
-
-    # execute and collect the first (and only) batch
-    result = df.collect()[0]
-
-    assert result.column(0) == pa.array(["logical_plan", "physical_plan"])
+    df.explain()

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -185,7 +185,7 @@ def test_explain(df):
     df = df.select(
         column("a") + column("b"),
         column("a") - column("b"),
-        )
+    )
 
     df = df.explain(False, False)
 

--- a/datafusion/tests/test_dataframe.py
+++ b/datafusion/tests/test_dataframe.py
@@ -179,3 +179,17 @@ def test_struct_select(struct_df):
 
     assert result.column(0) == pa.array([5, 7, 9])
     assert result.column(1) == pa.array([-3, -3, -3])
+
+
+def test_explain(df):
+    df = df.select(
+        column("a") + column("b"),
+        column("a") - column("b"),
+        )
+
+    df = df.explain(False, False)
+
+    # execute and collect the first (and only) batch
+    result = df.collect()[0]
+
+    assert result.column(0) == pa.array(["logical_plan", "physical_plan"])

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -127,4 +127,9 @@ impl PyDataFrame {
             .join(right.df, join_type, &join_keys.0, &join_keys.1)?;
         Ok(Self::new(df))
     }
+
+    fn explain(&self, verbose: bool, analyze: bool) -> PyResult<Self> {
+        let df = self.df.explain(verbose, analyze)?;
+        Ok(Self::new(df))
+    }
 }

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -128,8 +128,11 @@ impl PyDataFrame {
         Ok(Self::new(df))
     }
 
-    fn explain(&self, verbose: bool, analyze: bool) -> PyResult<Self> {
+    /// Print the query plan
+    #[args(verbose = false, analyze = false)]
+    fn explain(&self, py: Python, verbose: bool, analyze: bool) -> PyResult<()> {
         let df = self.df.explain(verbose, analyze)?;
-        Ok(Self::new(df))
+        let batches = wait_for_future(py, df.collect())?;
+        Ok(pretty::print_batches(&batches)?)
     }
 }


### PR DESCRIPTION
Closes https://github.com/datafusion-contrib/datafusion-python/issues/35

This PR adds the `explain` method to `PyDataFrame`.

```
>>> from datafusion import ExecutionContext
>>> ctx = ExecutionContext()
>>> ctx.register_parquet("store_sales", "/mnt/bigdata/tpcds/sf100-parquet/store_sales.dat")
>>> df = ctx.sql("SELECT count(*) FROM store_sales")
>>> df.explain()
+---------------+-------------------------------------------------------------+
| plan_type     | plan                                                        |
+---------------+-------------------------------------------------------------+
| logical_plan  | Projection: #COUNT(UInt8(1))                                |
|               |   Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]         |
|               |     TableScan: store_sales projection=Some([0])             |
| physical_plan | ProjectionExec: expr=[COUNT(UInt8(1))@0 as COUNT(UInt8(1))] |
|               |   ProjectionExec: expr=[287997024 as COUNT(UInt8(1))]       |
|               |     EmptyExec: produce_one_row=true                         |
|               |                                                             |
+---------------+-------------------------------------------------------------+
```